### PR TITLE
Return WARNING/CRITICAL in maintenance mode only

### DIFF
--- a/check_vmware_api.pl
+++ b/check_vmware_api.pl
@@ -2272,13 +2272,18 @@ sub host_runtime_info
 		elsif ($subcommand eq "MAINTENANCE")
 		{
 			my %host_maintenance_state = (0 => "no", 1 => "yes");
-			$output = "maintenance=" . $host_maintenance_state{$runtime->inMaintenanceMode};
+			my $state = $runtime->inMaintenanceMode;
+			$output = "maintenance=" . $host_maintenance_state{$state};
 			$res = OK;
-			if ($addopts eq "maintwarn") {
-				$res = WARNING;
-			}
-			elsif ($addopts eq "maintcrit") {
-				$res = CRITICAL;
+			if ($state) {
+				if (!defined($addopts)) {
+				}
+				elsif ($addopts eq "maintwarn") {
+					$res = WARNING;
+				}
+				elsif ($addopts eq "maintcrit") {
+					$res = CRITICAL;
+				}
 			}
 		}
 		elsif (($subcommand eq "LIST") || ($subcommand eq "LISTVM"))


### PR DESCRIPTION
Using the "maintwarn" option, the script would return with exit code 1,
even if the system was not in maintenance mode.
Without that option, the script would fail
because $addopts is undefined.
A workaround is to use -o "".
Alternatively, // '' could be added to line 512.